### PR TITLE
Ensure header is visible even with large white images.

### DIFF
--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -208,9 +208,9 @@ open class LightboxController: UIViewController {
 
     headerView.frame = CGRect(
       x: 0,
-      y: 0,
+      y: 15,
       width: view.bounds.width,
-      height: 60
+      height: 45
     )
     
     if !presented {

--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -195,7 +195,7 @@ open class LightboxController: UIViewController {
   open override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
 
-    scrollView.frame = calcScrollViewFrame(view.bounds.size)
+    scrollView.frame = view.bounds
     footerView.frame.size = CGSize(
       width: view.bounds.width,
       height: 100
@@ -208,9 +208,9 @@ open class LightboxController: UIViewController {
 
     headerView.frame = CGRect(
       x: 0,
-      y: 16,
+      y: 0,
       width: view.bounds.width,
-      height: 45
+      height: 60
     )
     
     if !presented {
@@ -303,10 +303,10 @@ open class LightboxController: UIViewController {
   // MARK: - Layout
 
   open func configureLayout(_ size: CGSize) {
-    scrollView.frame = calcScrollViewFrame(size)
+    scrollView.frame.size = size
     scrollView.contentSize = CGSize(
       width: size.width * CGFloat(numberOfPages) + spacing * CGFloat(numberOfPages - 1),
-      height: scrollView.frame.height)
+      height: size.height)
     scrollView.contentOffset = CGPoint(x: CGFloat(currentPage) * (size.width + spacing), y: 0)
 
     for (index, pageView) in pageViews.enumerated() {
@@ -325,16 +325,6 @@ open class LightboxController: UIViewController {
     overlayView.resizeGradientLayer()
   }
 
-  fileprivate func calcScrollViewFrame(_ size: CGSize) -> CGRect {
-    let headerVisible = headerView.alpha == 1
-    let headerHeight = headerView.frame.minY + headerView.frame.height
-    if (headerVisible) {
-      return CGRect(x: 0, y: headerHeight, width: size.width, height: size.height - headerHeight*2)
-    } else {
-      return CGRect(x: 0, y: 0, width: size.width, height: size.height)
-    }
-  }
-
   fileprivate func loadDynamicBackground(_ image: UIImage) {
     backgroundView.image = image
     backgroundView.layer.add(CATransition(), forKey: "fade")
@@ -349,9 +339,7 @@ open class LightboxController: UIViewController {
       self.headerView.alpha = alpha
       self.footerView.alpha = alpha
       pageView?.playButton.alpha = alpha
-    }, completion: {_ in
-      self.configureLayout(self.view.bounds.size)
-    })
+    }, completion: nil)
   }
 
   // MARK: - Helper functions

--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -195,7 +195,7 @@ open class LightboxController: UIViewController {
   open override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
 
-    scrollView.frame = view.bounds
+    scrollView.frame = calcScrollViewFrame(view.bounds.size)
     footerView.frame.size = CGSize(
       width: view.bounds.width,
       height: 100
@@ -210,7 +210,7 @@ open class LightboxController: UIViewController {
       x: 0,
       y: 16,
       width: view.bounds.width,
-      height: 100
+      height: 45
     )
     
     if !presented {
@@ -303,10 +303,10 @@ open class LightboxController: UIViewController {
   // MARK: - Layout
 
   open func configureLayout(_ size: CGSize) {
-    scrollView.frame.size = size
+    scrollView.frame = calcScrollViewFrame(size)
     scrollView.contentSize = CGSize(
       width: size.width * CGFloat(numberOfPages) + spacing * CGFloat(numberOfPages - 1),
-      height: size.height)
+      height: scrollView.frame.height)
     scrollView.contentOffset = CGPoint(x: CGFloat(currentPage) * (size.width + spacing), y: 0)
 
     for (index, pageView) in pageViews.enumerated() {
@@ -325,6 +325,16 @@ open class LightboxController: UIViewController {
     overlayView.resizeGradientLayer()
   }
 
+  fileprivate func calcScrollViewFrame(_ size: CGSize) -> CGRect {
+    let headerVisible = headerView.alpha == 1
+    let headerHeight = headerView.frame.minY + headerView.frame.height
+    if (headerVisible) {
+      return CGRect(x: 0, y: headerHeight, width: size.width, height: size.height - headerHeight*2)
+    } else {
+      return CGRect(x: 0, y: 0, width: size.width, height: size.height)
+    }
+  }
+
   fileprivate func loadDynamicBackground(_ image: UIImage) {
     backgroundView.image = image
     backgroundView.layer.add(CATransition(), forKey: "fade")
@@ -339,7 +349,9 @@ open class LightboxController: UIViewController {
       self.headerView.alpha = alpha
       self.footerView.alpha = alpha
       pageView?.playButton.alpha = alpha
-    }, completion: nil)
+    }, completion: {_ in
+      self.configureLayout(self.view.bounds.size)
+    })
   }
 
   // MARK: - Helper functions

--- a/Source/Views/HeaderView.swift
+++ b/Source/Views/HeaderView.swift
@@ -67,9 +67,13 @@ open class HeaderView: UIView {
   public init() {
     super.init(frame: CGRect.zero)
 
-    backgroundColor = UIColor.clear
+    backgroundColor = UIColor.black.withAlphaComponent(0.2)
 
-    [closeButton, deleteButton].forEach { addSubview($0) }
+    let buttonView = UIView()
+    addSubview(buttonView)
+    buttonView.frame = CGRect(x: 0, y: 15, width: self.bounds.width, height: self.bounds.height)
+
+    [closeButton, deleteButton].forEach { buttonView.addSubview($0) }
   }
 
   public required init?(coder aDecoder: NSCoder) {

--- a/Source/Views/HeaderView.swift
+++ b/Source/Views/HeaderView.swift
@@ -67,13 +67,9 @@ open class HeaderView: UIView {
   public init() {
     super.init(frame: CGRect.zero)
 
-    backgroundColor = UIColor.black.withAlphaComponent(0.2)
+    backgroundColor = UIColor.clear
 
-    let buttonView = UIView()
-    addSubview(buttonView)
-    buttonView.frame = CGRect(x: 0, y: 15, width: self.bounds.width, height: self.bounds.height)
-
-    [closeButton, deleteButton].forEach { buttonView.addSubview($0) }
+    [closeButton, deleteButton].forEach { addSubview($0) }
   }
 
   public required init?(coder aDecoder: NSCoder) {

--- a/Source/Views/PageView.swift
+++ b/Source/Views/PageView.swift
@@ -53,7 +53,7 @@ class PageView: UIScrollView {
   weak var pageViewDelegate: PageViewDelegate?
 
   var hasZoomed: Bool {
-    return zoomScale != 1.0
+    return zoomScale != minimumZoomScale
   }
 
   // MARK: - Initializers
@@ -138,9 +138,8 @@ class PageView: UIScrollView {
     let newZoomScale = zoomScale > minimumZoomScale
       ? minimumZoomScale
       : maximumZoomScale
-
-    let width = contentFrame.size.width / newZoomScale
-    let height = contentFrame.size.height / newZoomScale
+    let width = imageView.frame.width / newZoomScale
+    let height = imageView.frame.height / newZoomScale
     let x = pointInView.x - (width / 2.0)
     let y = pointInView.y - (height / 2.0)
 
@@ -169,20 +168,30 @@ class PageView: UIScrollView {
     }
 
     let imageViewSize = imageView.frame.size
-    let imageSize = image.size
-    let realImageViewSize: CGSize
 
+    let imageSize = image.size
+    let newImageViewSize: CGSize
+
+    // Size the imageView so that it has the same aspect ratio as the image, while using the
+    // maximum possible width or height.
     if imageSize.width / imageSize.height > imageViewSize.width / imageViewSize.height {
-      realImageViewSize = CGSize(
+      newImageViewSize = CGSize(
         width: imageViewSize.width,
         height: imageViewSize.width / imageSize.width * imageSize.height)
     } else {
-      realImageViewSize = CGSize(
+      newImageViewSize = CGSize(
         width: imageViewSize.height / imageSize.height * imageSize.width,
         height: imageViewSize.height)
     }
 
-    imageView.frame = CGRect(origin: CGPoint.zero, size: realImageViewSize)
+    imageView.frame = CGRect(origin: CGPoint.zero, size: newImageViewSize)
+
+    // We zoom the image out if necessary to leave space for the header / footer to be visible.
+    let maxHeight = imageViewSize.height - 120
+    if (imageView.frame.height > maxHeight) {
+      minimumZoomScale = maxHeight / imageView.frame.height
+      zoomScale = minimumZoomScale
+    }
 
     centerImageView()
   }

--- a/Source/Views/PageView.swift
+++ b/Source/Views/PageView.swift
@@ -24,7 +24,7 @@ class PageView: UIScrollView {
     let button = UIButton(type: .custom)
     button.frame.size = CGSize(width: 60, height: 60)
     var buttonImage = AssetManager.image("lightbox_play")
-    
+
     // Note by Elvis Nuñez on Mon 22 Jun 08:06
     // When using SPM you might find that assets are note included. This is a workaround to provide default assets
     // under iOS 13 so using SPM can work without problems.
@@ -168,12 +168,11 @@ class PageView: UIScrollView {
     }
 
     let imageViewSize = imageView.frame.size
-
     let imageSize = image.size
-    let newImageViewSize: CGSize
 
     // Size the imageView so that it has the same aspect ratio as the image, while using the
     // maximum possible width or height.
+    let newImageViewSize: CGSize
     if imageSize.width / imageSize.height > imageViewSize.width / imageViewSize.height {
       newImageViewSize = CGSize(
         width: imageViewSize.width,

--- a/Source/Views/PageView.swift
+++ b/Source/Views/PageView.swift
@@ -187,7 +187,7 @@ class PageView: UIScrollView {
 
     // We zoom the image out if necessary to leave space for the header / footer to be visible.
     let maxHeight = imageViewSize.height - 120
-    if (imageView.frame.height > maxHeight) {
+    if (maxHeight > 0 && imageView.frame.height > maxHeight) {
       minimumZoomScale = maxHeight / imageView.frame.height
       zoomScale = minimumZoomScale
     }

--- a/iOSDemo/ViewController.swift
+++ b/iOSDemo/ViewController.swift
@@ -37,8 +37,9 @@ class ViewController: UIViewController {
                 text: "Photography is the science, art, application and practice of creating durable images by recording light or other electromagnetic radiation, either electronically by means of an image sensor, or chemically by means of a light-sensitive material such as photographic film"
             ),
             
-            LightboxImage(imageURL: URL(string: "https://via.placeholder.com/300x600.png/fff/000")!),
-
+            LightboxImage(imageURL: URL(string: "https://via.placeholder.com/300x600.png/fff/09f")!),
+            
+            
             LightboxImage(
                 image: UIImage(named: "photo2")!,
                 text: "Emoji 😍 (/ɪˈmoʊdʒi/; singular emoji, plural emoji or emojis;[4] from the Japanese 絵文字えもじ, pronounced [emodʑi]) are ideograms and smileys used in electronic messages and web pages. Emoji are used much like emoticons and exist in various genres, including facial expressions, common objects, places and types of weather 🌅☔️💦, and animals 🐶🐱",

--- a/iOSDemo/ViewController.swift
+++ b/iOSDemo/ViewController.swift
@@ -2,7 +2,7 @@ import UIKit
 import Lightbox
 
 class ViewController: UIViewController {
-  
+
   lazy var showButton: UIButton = { [unowned self] in
     let button = UIButton()
     button.addTarget(self, action: #selector(showLightbox), for: .touchUpInside)
@@ -11,10 +11,10 @@ class ViewController: UIViewController {
     button.titleLabel?.font = UIFont(name: "AvenirNextCondensed-DemiBold", size: 30)
     button.frame = UIScreen.main.bounds
     button.autoresizingMask = [.flexibleTopMargin, .flexibleLeftMargin, .flexibleRightMargin, .flexibleBottomMargin]
-    
+
     return button
   }()
-  
+
   override func viewDidLoad() {
     super.viewDidLoad()
 
@@ -24,9 +24,9 @@ class ViewController: UIViewController {
     title = "Lightbox"
     LightboxConfig.preload = 2
   }
-  
+
   // MARK: - Action methods
-  
+
     @objc func showLightbox() {
         let images = [
             LightboxImage(imageURL: URL(string: "https://media.giphy.com/media/Ku65904QQe4yez448B/giphy.gif")!),
@@ -36,10 +36,10 @@ class ViewController: UIViewController {
                 image: UIImage(named: "photo1")!,
                 text: "Photography is the science, art, application and practice of creating durable images by recording light or other electromagnetic radiation, either electronically by means of an image sensor, or chemically by means of a light-sensitive material such as photographic film"
             ),
-            
-            LightboxImage(imageURL: URL(string: "https://via.placeholder.com/300x600.png/fff/09f")!),
-            
-            
+
+            LightboxImage(imageURL: URL(string: "https://via.placeholder.com/300x600.png/fff/000")!),
+
+
             LightboxImage(
                 image: UIImage(named: "photo2")!,
                 text: "Emoji 😍 (/ɪˈmoʊdʒi/; singular emoji, plural emoji or emojis;[4] from the Japanese 絵文字えもじ, pronounced [emodʑi]) are ideograms and smileys used in electronic messages and web pages. Emoji are used much like emoticons and exist in various genres, including facial expressions, common objects, places and types of weather 🌅☔️💦, and animals 🐶🐱",
@@ -51,10 +51,10 @@ class ViewController: UIViewController {
             ),
             LightboxImage(imageURL: URL(string: "https://c.tenor.com/kccsHXtdDn0AAAAC/alcohol-wine.gif")!)
         ]
-        
+
         let controller = LightboxController(images: images)
         controller.dynamicBackground = true
-        
+
         present(controller, animated: true, completion: nil)
     }
 }

--- a/iOSDemo/ViewController.swift
+++ b/iOSDemo/ViewController.swift
@@ -37,9 +37,8 @@ class ViewController: UIViewController {
                 text: "Photography is the science, art, application and practice of creating durable images by recording light or other electromagnetic radiation, either electronically by means of an image sensor, or chemically by means of a light-sensitive material such as photographic film"
             ),
             
-            LightboxImage(imageURL: URL(string: "https://via.placeholder.com/300.png/09f/fff")!),
-            
-            
+            LightboxImage(imageURL: URL(string: "https://via.placeholder.com/300x600.png/fff/000")!),
+
             LightboxImage(
                 image: UIImage(named: "photo2")!,
                 text: "Emoji 😍 (/ɪˈmoʊdʒi/; singular emoji, plural emoji or emojis;[4] from the Japanese 絵文字えもじ, pronounced [emodʑi]) are ideograms and smileys used in electronic messages and web pages. Emoji are used much like emoticons and exist in various genres, including facial expressions, common objects, places and types of weather 🌅☔️💦, and animals 🐶🐱",


### PR DESCRIPTION
Fixes https://app.asana.com/0/1204781676683007/1206803553364508 (once we pull this into the Shortwave build).

If an image would be too tall and overlap the header then we zoom out enough so that it doesn't.  The user can still zoom in via pinch-to-zoom, but that will hide the header (existing behavior) so that overlap isn't an issue.

# Before:
![image](https://github.com/shortwave/Lightbox/assets/206364/fbb7a7c1-a78a-4289-b5e8-56c689334f90)

# After:
<img width="394" alt="image" src="https://github.com/shortwave/Lightbox/assets/206364/053f334c-dbca-4d35-bab4-01b55550c785">

(and you can still hide the header by tapping or zooming)
![image](https://github.com/shortwave/Lightbox/assets/206364/7e0bf942-38a1-4610-b15f-534da13ea1f7)
