### PR TITLE
Add translucent background to header buttons to ensure they're visible on light images.

### DIFF
--- a/Source/Views/HeaderView.swift
+++ b/Source/Views/HeaderView.swift
@@ -89,6 +89,9 @@ open class HeaderView: UIView {
   }
 
   @objc func closeButtonDidPress(_ button: UIButton) {
+    let generator = UIImpactFeedbackGenerator(style: .medium)
+    generator.prepare()
+    generator.impactOccurred()
     delegate?.headerView(self, didPressCloseButton: button)
   }
 }

--- a/Source/Views/HeaderView.swift
+++ b/Source/Views/HeaderView.swift
@@ -12,6 +12,9 @@ open class HeaderView: UIView {
       attributes: LightboxConfig.CloseButton.textAttributes)
 
     let button = UIButton(type: .system)
+    button.backgroundColor = UIColor.black.withAlphaComponent(0.2)
+    button.layer.cornerRadius = 10
+    button.contentEdgeInsets = UIEdgeInsets(top: 5, left: 8, bottom: 5, right: 8)
 
     button.setAttributedTitle(title, for: UIControl.State())
 
@@ -39,6 +42,9 @@ open class HeaderView: UIView {
       attributes: LightboxConfig.DeleteButton.textAttributes)
 
     let button = UIButton(type: .system)
+    button.backgroundColor = UIColor.black.withAlphaComponent(0.2)
+    button.layer.cornerRadius = 10
+    button.contentEdgeInsets = UIEdgeInsets(top: 5, left: 8, bottom: 5, right: 8)
 
     button.setAttributedTitle(title, for: .normal)
 

--- a/Source/Views/HeaderView.swift
+++ b/Source/Views/HeaderView.swift
@@ -13,7 +13,7 @@ open class HeaderView: UIView {
 
     let button = UIButton(type: .system)
     button.backgroundColor = UIColor.black.withAlphaComponent(0.2)
-    button.layer.cornerRadius = 10
+    button.layer.cornerRadius = 8
     button.contentEdgeInsets = UIEdgeInsets(top: 5, left: 8, bottom: 5, right: 8)
 
     button.setAttributedTitle(title, for: UIControl.State())
@@ -43,7 +43,7 @@ open class HeaderView: UIView {
 
     let button = UIButton(type: .system)
     button.backgroundColor = UIColor.black.withAlphaComponent(0.2)
-    button.layer.cornerRadius = 10
+    button.layer.cornerRadius = 8
     button.contentEdgeInsets = UIEdgeInsets(top: 5, left: 8, bottom: 5, right: 8)
 
     button.setAttributedTitle(title, for: .normal)

--- a/iOSDemo/ViewController.swift
+++ b/iOSDemo/ViewController.swift
@@ -37,8 +37,8 @@ class ViewController: UIViewController {
                 text: "Photography is the science, art, application and practice of creating durable images by recording light or other electromagnetic radiation, either electronically by means of an image sensor, or chemically by means of a light-sensitive material such as photographic film"
             ),
             
-            LightboxImage(imageURL: URL(string: "https://via.placeholder.com/300.png/09f/fff")!),
-            
+            LightboxImage(imageURL: URL(string: "https://via.placeholder.com/300x600.png/fff/000")!),
+
             
             LightboxImage(
                 image: UIImage(named: "photo2")!,


### PR DESCRIPTION
Much simple alternative to #1.

Fixes https://app.asana.com/0/1204781676683007/1206803553364508 (once we pull this into the Shortwave build).

# Before:
![image](https://github.com/shortwave/Lightbox/assets/206364/bbf332cd-00b6-444e-a5a4-e0d80cf1f6ae)

# After:
![image](https://github.com/shortwave/Lightbox/assets/206364/ee0eaed4-4669-44e2-b485-1722eb58c96f)

# After with image that isn't full-height:
![image](https://github.com/shortwave/Lightbox/assets/206364/ceda7081-e6d8-42bc-aea8-6a1a63e68108)
