### PR TITLE
Add extra padding when the status bar isn't hidden.

### DIFF
--- a/Source/Views/HeaderView.swift
+++ b/Source/Views/HeaderView.swift
@@ -102,11 +102,12 @@ extension HeaderView: LayoutConfigurable {
 
   @objc public func configureLayout() {
     let topPadding: CGFloat
+    let statusBarPadding: CGFloat = LightboxConfig.hideStatusBar ? 0 : 8
 
     if #available(iOS 11, *) {
-      topPadding = safeAreaInsets.top
+      topPadding = safeAreaInsets.top + statusBarPadding
     } else {
-      topPadding = 0
+      topPadding = statusBarPadding
     }
 
     closeButton.frame.origin = CGPoint(

--- a/iOSDemo/ViewController.swift
+++ b/iOSDemo/ViewController.swift
@@ -23,6 +23,8 @@ class ViewController: UIViewController {
     view.addSubview(showButton)
     title = "Lightbox"
     LightboxConfig.preload = 2
+    // Ideally we'd hide the status bar but in shortwave it doesn't work because react-native is controlling it.
+    LightboxConfig.hideStatusBar = false
   }
   
   // MARK: - Action methods


### PR DESCRIPTION
With the buttons having a background now, they were squished up next to the iOS status bar and looked kind of awkward. Ideally we'd hide the status bar while the lightbox is open, but that doesn't work in Shortwave because React Native is controlling the status bar. So I'm adding some padding to make them look better.

# Before:
![image](https://github.com/shortwave/Lightbox/assets/206364/d71e1d53-fee6-4e37-94bb-85894332fb2f)

# After:
![image](https://github.com/shortwave/Lightbox/assets/206364/9fdc2d42-da69-4904-b9d6-85024c611cf9)
